### PR TITLE
Drop raw API requests in favour of pywikibot internals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests>=2.31.0,<3.0
 pywikibot>=8.3.1,<9.0
 mwparserfromhell
 python-dateutil


### PR DESCRIPTION
This reduces the overall numbers of requests sent to Commons by
a) relying on built-in pywikibot caching
b) only requesting the historic sdc data when we know it exists

Also dropping trailing whitespace and unused variable.