### PR TITLE
Avoid crashing on images with deleted captions.

### DIFF
--- a/commonsdiff.py
+++ b/commonsdiff.py
@@ -272,6 +272,8 @@ class CommonsFile(object):
             old_sdc_labels = old_sdc_content.get("labels")
             if old_sdc_labels:
                 for key in old_sdc_labels.keys():
+                    if not labels.get(key):  # deleted captions result in empty values
+                        continue
                     old_captions.append({key:labels.get(key).get('value')})
         
         # now we compare old and new captions


### PR DESCRIPTION
Deleted captions leave an entry without internal values.
See e.g. Ultuna - Nordiska museet - NMAx.0000410.tif where the "ar" caption was deleted